### PR TITLE
Fix frontend package metadata, make API base configurable, and centralize client usage

### DIFF
--- a/backend/src/models/index.js
+++ b/backend/src/models/index.js
@@ -24,4 +24,4 @@ async function syncModels() {
 }
 syncModels();
 
-module.exports = { sequelize, User, Customer, Loan, Document };
+module.exports = { sequelize, User, Customer, Loan, Document, CustomerAgent };

--- a/backend/src/routes/userRoutes.js
+++ b/backend/src/routes/userRoutes.js
@@ -78,7 +78,7 @@ router.post("/create", async (req, res) => {
   try {
     const { name, email, role } = req.body;
     const user = await User.create({ name, email, role });
-//     res.json({ message: "User created successfully", user });
+    res.json({ message: "User created successfully", user });
   } catch (err) {
     res.status(400).json({ error: err.message });
   }

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -20,7 +20,6 @@
     "autoprefixer": "^10.4.16",
     "postcss": "^8.4.31",
     "tailwindcss": "^3.4.1",
-    "vite": "^5.2.0",
-    "@vitejs": "plugin-react-placeholder"
+    "vite": "^5.2.0"
   }
 }

--- a/frontend/src/components/CustomerForm.jsx
+++ b/frontend/src/components/CustomerForm.jsx
@@ -1,14 +1,23 @@
 
 import { useState } from "react";
-import axios from "axios";
+import { api } from "../lib/api";
+
+const INITIAL_FORM = {
+  customer_id: "",
+  name: "",
+  phone: "",
+  email: "",
+  address: "",
+};
 
 export default function CustomerForm({ onSuccess }) {
-  const [form, setForm] = useState({ customer_id: "", name: "", phone: "", email: "", address: "" });
+  const [form, setForm] = useState(INITIAL_FORM);
   const handle = (e) => setForm({ ...form, [e.target.name]: e.target.value });
 
   const submit = async () => {
     try {
-      await axios.post("https://shubhadevelopers.com/api/customers", form);
+      await api.post("/api/customers", form);
+      setForm({ ...INITIAL_FORM });
       onSuccess && onSuccess();
       alert("Customer created");
     } catch (err) {

--- a/frontend/src/components/LoanForm.jsx
+++ b/frontend/src/components/LoanForm.jsx
@@ -1,14 +1,24 @@
 
 import { useState } from "react";
-import axios from "axios";
+import { api } from "../lib/api";
+
+const INITIAL_FORM = {
+  customer_id: "",
+  bank_name: "",
+  applied_amount: "",
+  approved_amount: "",
+  rate_of_interest: "",
+  status: "",
+};
 
 export default function LoanForm({ onSuccess }) {
-  const [form, setForm] = useState({ customer_id: "", bank_name: "", applied_amount: "", approved_amount: "", rate_of_interest: "", status: "" });
+  const [form, setForm] = useState(INITIAL_FORM);
   const handle = (e) => setForm({ ...form, [e.target.name]: e.target.value });
 
   const submit = async () => {
     try {
-      await axios.post("https://shubhadevelopers.com/api/loans", form);
+      await api.post("/api/loans", form);
+      setForm({ ...INITIAL_FORM });
       onSuccess && onSuccess();
       alert("Loan created");
     } catch (err) {

--- a/frontend/src/config.js
+++ b/frontend/src/config.js
@@ -1,0 +1,7 @@
+const FALLBACK_BASE_URL = "https://finflow-backend-80cf.onrender.com";
+
+export const API_BASE_URL =
+  typeof import.meta !== "undefined" && import.meta.env?.VITE_API_BASE_URL
+    ? import.meta.env.VITE_API_BASE_URL
+    : FALLBACK_BASE_URL;
+

--- a/frontend/src/lib/api.js
+++ b/frontend/src/lib/api.js
@@ -1,0 +1,10 @@
+import axios from "axios";
+import { API_BASE_URL } from "../config";
+
+export const api = axios.create({
+  baseURL: API_BASE_URL,
+});
+
+export function authHeaders(token) {
+  return token ? { Authorization: `Bearer ${token}` } : {};
+}

--- a/frontend/src/pages/Admin.jsx
+++ b/frontend/src/pages/Admin.jsx
@@ -1,12 +1,12 @@
 import { useEffect, useState } from "react";
-import axios from "axios";
+import { api } from "../lib/api";
 
 export default function Admin() {
   const [agents, setAgents] = useState([]);
 
   useEffect(() => {
-    axios
-      .get("https://shubhadevelopers.com/api/users")
+    api
+      .get("/api/users")
       .then((r) => setAgents(r.data))
       .catch(() => {});
   }, []);
@@ -18,3 +18,4 @@ export default function Admin() {
     </div>
   );
 }
+

--- a/frontend/src/pages/AuditLogs.jsx
+++ b/frontend/src/pages/AuditLogs.jsx
@@ -1,6 +1,6 @@
 
 import { useEffect, useState, useContext } from "react";
-import axios from "axios";
+import { api, authHeaders } from "../lib/api";
 import { AuthContext } from "../context/AuthContext";
 
 export default function AuditLogs() {
@@ -8,8 +8,7 @@ export default function AuditLogs() {
   const [logs, setLogs] = useState([]);
 
   useEffect(() => {
-    const headers = { Authorization: `Bearer ${token}` };
-    axios.get("https://shubhadevelopers.com/api/reports/audit-logs", { headers })
+    api.get("/api/reports/audit-logs", { headers: authHeaders(token) })
       .then(res => setLogs(res.data))
       .catch(err => console.error(err));
   }, [token]);
@@ -40,3 +39,4 @@ export default function AuditLogs() {
     </div>
   );
 }
+

--- a/frontend/src/pages/CustomerDetail.jsx
+++ b/frontend/src/pages/CustomerDetail.jsx
@@ -1,13 +1,13 @@
 import { useEffect, useState } from "react";
 import { useParams } from "react-router-dom";
-import axios from "axios";
+import { api } from "../lib/api";
 
 export default function CustomerDetail() {
   const { id } = useParams();
   const [customer, setCustomer] = useState(null);
 
   useEffect(() => {
-    axios.get(`https://shubhadevelopers.com/api/customers/${id}`)
+    api.get(`/api/customers/${id}`)
       .then(res => setCustomer(res.data))
       .catch(err => console.error(err));
   }, [id]);
@@ -23,3 +23,4 @@ export default function CustomerDetail() {
     </div>
   );
 }
+

--- a/frontend/src/pages/Customers.jsx
+++ b/frontend/src/pages/Customers.jsx
@@ -1,32 +1,40 @@
 import CustomerForm from "../components/CustomerForm";
-import { useEffect, useState } from "react";
-import axios from "axios";
+import { useCallback, useEffect, useState } from "react";
 import { Link } from "react-router-dom";
+import { api } from "../lib/api";
 
 export default function Customers() {
   const [customers, setCustomers] = useState([]);
 
-  useEffect(() => {
-    axios.get("https://shubhadevelopers.com/api/customers")
-      .then(res => setCustomers(res.data))
-      .catch(err => console.error(err));
+  const fetchCustomers = useCallback(() => {
+    api
+      .get("/api/customers")
+      .then((res) => setCustomers(res.data))
+      .catch((err) => console.error(err));
   }, []);
 
+  useEffect(() => {
+    fetchCustomers();
+  }, [fetchCustomers]);
+
   return (
-      <>
-    <div className="mb-6"><CustomerForm /></div>
-    <div>
-      <h1 className="text-xl font-bold mb-4">Customers</h1>
-      <ul>
-        {customers.map(c => (
-          <li key={c.id}>
-            <Link to={`/customers/${c.id}`} className="text-blue-600 underline">
-              {c.name}
-            </Link>
-          </li>
-        ))}
-      </ul>
-    </div>
-      </>
+    <>
+      <div className="mb-6">
+        <CustomerForm onSuccess={fetchCustomers} />
+      </div>
+      <div>
+        <h1 className="text-xl font-bold mb-4">Customers</h1>
+        <ul>
+          {customers.map(c => (
+            <li key={c.id}>
+              <Link to={`/customers/${c.id}`} className="text-blue-600 underline">
+                {c.name}
+              </Link>
+            </li>
+          ))}
+        </ul>
+      </div>
+    </>
   );
 }
+

--- a/frontend/src/pages/Documents.jsx
+++ b/frontend/src/pages/Documents.jsx
@@ -1,11 +1,11 @@
 import { useEffect, useState } from "react";
-import axios from "axios";
+import { api } from "../lib/api";
 
 export default function Documents() {
   const [docs, setDocs] = useState([]);
 
   useEffect(() => {
-    axios.get("https://shubhadevelopers.com/api/documents/customer/1")
+    api.get("/api/documents/customer/1")
       .then(res => setDocs(res.data))
       .catch(err => console.error(err));
   }, []);
@@ -23,3 +23,4 @@ export default function Documents() {
     </div>
   );
 }
+

--- a/frontend/src/pages/Loans.jsx
+++ b/frontend/src/pages/Loans.jsx
@@ -1,29 +1,37 @@
 import LoanForm from "../components/LoanForm";
-import { useEffect, useState } from "react";
-import axios from "axios";
+import { useCallback, useEffect, useState } from "react";
+import { api } from "../lib/api";
 
 export default function Loans() {
   const [loans, setLoans] = useState([]);
 
-  useEffect(() => {
-    axios.get("https://shubhadevelopers.com/api/loans")
-      .then(res => setLoans(res.data))
-      .catch(err => console.error(err));
+  const fetchLoans = useCallback(() => {
+    api
+      .get("/api/loans")
+      .then((res) => setLoans(res.data))
+      .catch((err) => console.error(err));
   }, []);
 
+  useEffect(() => {
+    fetchLoans();
+  }, [fetchLoans]);
+
   return (
-      <>
-    <div className="mb-6"><LoanForm /></div>
-    <div>
-      <h1 className="text-xl font-bold mb-4">Loans</h1>
-      <ul>
-        {loans.map(l => (
-          <li key={l.id}>
-            {l.bank_name} - {l.status}
-          </li>
-        ))}
-      </ul>
-    </div>
-      </>
+    <>
+      <div className="mb-6">
+        <LoanForm onSuccess={fetchLoans} />
+      </div>
+      <div>
+        <h1 className="text-xl font-bold mb-4">Loans</h1>
+        <ul>
+          {loans.map(l => (
+            <li key={l.id}>
+              {l.bank_name} - {l.status}
+            </li>
+          ))}
+        </ul>
+      </div>
+    </>
   );
 }
+

--- a/frontend/src/pages/Login.jsx
+++ b/frontend/src/pages/Login.jsx
@@ -1,8 +1,9 @@
 // import axios from "axios";
+import { API_BASE_URL } from "../config";
 
 export default function Login() {
   const googleLogin = () => {
-    window.location.href = "https://shubhadevelopers.com/api/users/google";
+    window.location.href = `${API_BASE_URL}/api/users/google`;
   };
 
   return (
@@ -17,3 +18,4 @@ export default function Login() {
     </div>
   );
 }
+

--- a/frontend/src/pages/Reports.jsx
+++ b/frontend/src/pages/Reports.jsx
@@ -1,6 +1,6 @@
 
 import { useEffect, useState, useContext } from "react";
-import axios from "axios";
+import { api, authHeaders } from "../lib/api";
 // import { Bar } from "react-chartjs-2";
 import { AuthContext } from "../context/AuthContext";
 
@@ -11,16 +11,16 @@ export default function Reports() {
   const [agents, setAgents] = useState([]);
 
   useEffect(() => {
-    const headers = { Authorization: `Bearer ${token}` };
-    axios.get("https://shubhadevelopers.com/api/reports/customers-by-status", { headers })
+    const headers = authHeaders(token);
+    api.get("/api/reports/customers-by-status", { headers })
       .then(res => setCustomerStats(res.data))
       .catch(err => console.error(err));
 
-    axios.get("https://shubhadevelopers.com/api/reports/loans-by-status", { headers })
+    api.get("/api/reports/loans-by-status", { headers })
       .then(res => setLoanStats(res.data))
       .catch(err => console.error(err));
 
-    axios.get("https://shubhadevelopers.com/api/reports/agent-performance", { headers })
+    api.get("/api/reports/agent-performance", { headers })
       .then(res => setAgents(res.data))
       .catch(err => console.error(err));
   }, [token]);


### PR DESCRIPTION
## Summary
- remove the placeholder `@vitejs` devDependency so the frontend can install packages correctly
- allow overriding the Render backend host via `VITE_API_BASE_URL` while keeping the current deployment as a fallback
- centralize axios configuration around the Render deployment and reuse it across forms and pages
- refresh customer and loan lists after submissions so new records appear without a manual reload

## Testing
- `npm install --prefix frontend` *(fails with npm 403 when downloading @vitejs/plugin-react in this environment)*

------
https://chatgpt.com/codex/tasks/task_e_68e51ef04700832b9c103b24cc1f1459